### PR TITLE
Fix link for fetch

### DIFF
--- a/module-examples/top-level-await/modules/getColors.js
+++ b/module-examples/top-level-await/modules/getColors.js
@@ -1,5 +1,5 @@
 // fetch request
-const colors = fetch('https://raw.githubusercontent.com/mdn/js-examples/master/module-examples/top-level-await/data/colors.json')
+const colors = fetch('https://mdn.github.io/js-examples/module-examples/top-level-await/data/colors.json')
 	.then(response => response.json());
 
 export default await colors;

--- a/module-examples/top-level-await/modules/getColors.js
+++ b/module-examples/top-level-await/modules/getColors.js
@@ -1,5 +1,5 @@
 // fetch request
-const colors = fetch('https://mdn.github.io/js-examples/modules/top-level-await/data/colors.json')
+const colors = fetch('https://raw.githubusercontent.com/mdn/js-examples/master/module-examples/top-level-await/data/colors.json')
 	.then(response => response.json());
 
 export default await colors;


### PR DESCRIPTION
While going through an example of `await` in JavaScript's References, I found that the URL provided (which led to the repo's GitHub pages) to the fetch function in getColor.js was broken. Thus, the example could not be demonstrated. I fixed this by changing the URL to ~~`https://raw.githubusercontent.com/mdn/js-examples/master/module-examples/top-level-await/data/colors.json`~~.

edit: it seems like this issue is caused by a change in the folder name in a [previous change](https://github.com/mdn/js-examples/pull/17#issuecomment-1120963439), but the link was not updated accordingly in getColors.js. So I've changed the link to `https://mdn.github.io/js-examples/module-examples/top-level-await/data/colors.json` instead of the raw GitHub link